### PR TITLE
Added velocity scaling

### DIFF
--- a/ArduinoMidiDrums.ino
+++ b/ArduinoMidiDrums.ino
@@ -37,7 +37,6 @@
 #define LCYM_SCALE 50
 #define RCYM_SCALE 50
 #define KICK_SCALE 100
-#define unsigned short velScale[NUM_PIEZOS];
 
 //MIDI note defines for each trigger
 #define SNARE_NOTE 70
@@ -67,6 +66,9 @@ unsigned short slotMap[NUM_PIEZOS];
 
 //map that holds the respective note to each piezo
 unsigned short noteMap[NUM_PIEZOS];
+
+//map that holds the respective scales for each pad
+unsigned short velScale[NUM_PIEZOS];
 
 //map that holds the respective threshold to each piezo
 unsigned short thresholdMap[NUM_PIEZOS];

--- a/ArduinoMidiDrums.ino
+++ b/ArduinoMidiDrums.ino
@@ -30,6 +30,14 @@
 #define KICK_THRESHOLD 50
 #define START_SLOT 0     //first analog slot of piezos
 
+//Piezo scaling defines
+#define SNARE_SCALE 20    //    100 is 100% of raw value - that is no scaling
+#define LTOM_SCALE 50     //  < 100 scales the velocity down so that you have to hit harder to get maximum velocity
+#define RTOM_SCALE 50     //  > 100 scales the velocity up so you get maximum velocity with softer hits
+#define LCYM_SCALE 50
+#define RCYM_SCALE 50
+#define KICK_SCALE 100
+
 //MIDI note defines for each trigger
 #define SNARE_NOTE 70
 #define LTOM_NOTE 71
@@ -100,6 +108,13 @@ void setup()
   thresholdMap[3] = LCYM_THRESHOLD;
   thresholdMap[4] = SNARE_THRESHOLD;
   thresholdMap[5] = LTOM_THRESHOLD;  
+
+  velScale[0] = KICK_SCALE;
+  velScale[1] = RTOM_SCALE;
+  velScale[2] = LCYM_SCALE;
+  velScale[3] = LCYM_SCALE;
+  velScale[4] = SNARE_SCALE;
+  velScale[5] = LTOM_SCALE;
   
   noteMap[0] = KICK_NOTE;
   noteMap[1] = RTOM_NOTE;
@@ -187,7 +202,7 @@ void recordNewPeak(short slot, short newPeak)
   {
     noteReady[slot] = true;
     if(newPeak > noteReadyVelocity[slot])
-      noteReadyVelocity[slot] = newPeak;
+      noteReadyVelocity[slot] = newPeak * velScale[slot] / 100;
   }
   else if(newPeak < prevPeak && noteReady[slot])
   {

--- a/ArduinoMidiDrums.ino
+++ b/ArduinoMidiDrums.ino
@@ -37,6 +37,7 @@
 #define LCYM_SCALE 50
 #define RCYM_SCALE 50
 #define KICK_SCALE 100
+#define unsigned short velScale[NUM_PIEZOS];
 
 //MIDI note defines for each trigger
 #define SNARE_NOTE 70


### PR DESCRIPTION
Added Velocity scaling for each piezo to change how the velocity
responds to how hard you hit the pads.

If the scaling value is set below 100 then you have to hit the pad harder to reach maximum velocity.  This enables a greater control of the velocity from soft touches to really hard hits.
Also if you want less sensitivity then increase the scaling above 100 to make the velocity max out with soft hits.  This will help with beginners and kids where the velocity can be made to max out even with soft hits on the edge of the pads.

Scaling can be done on a per pad basis.